### PR TITLE
fix stream  audio cannot send to server.

### DIFF
--- a/ios/Classes/SwiftSoundStreamPlugin.swift
+++ b/ios/Classes/SwiftSoundStreamPlugin.swift
@@ -217,8 +217,19 @@ public class SwiftSoundStreamPlugin: NSObject, FlutterPlugin {
             }
         }
     }
+
+    private func configureAudioSession() {
+        do {
+          try AVAudioSession.sharedInstance().setCategory(
+            AVAudioSession.Category.playAndRecord,
+            options: [AVAudioSession.CategoryOptions.mixWithOthers]
+          )
+            try AVAudioSession.sharedInstance().setActive(true)
+        } catch { }
+    }
     
     private func startRecording(_ result: @escaping FlutterResult) {
+        configureAudioSession()
         resetEngineForRecord()
         startEngine()
         sendRecorderStatus(SoundStreamStatus.Playing)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sound_stream
 description: A Flutter plugin for streaming audio data from Mic and data to Audio engine without using a file.
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/CasperPas/flutter-sound-stream
 
 environment:


### PR DESCRIPTION
Some time the recorder will not work correct with data output.

Need to setup the `AVAudioSession` clearly before start recording.

[ref: https://stackoverflow.com/questions/41805381/avaudioengine-inputnode-installtap-crash-when-restarting-recording](https://stackoverflow.com/a/47902479/1530581)