### PR TITLE
Remove Yellow Microphone Indicator after recording in iOS

### DIFF
--- a/ios/Classes/SwiftSoundStreamPlugin.swift
+++ b/ios/Classes/SwiftSoundStreamPlugin.swift
@@ -227,6 +227,7 @@ public class SwiftSoundStreamPlugin: NSObject, FlutterPlugin {
     
     private func stopRecording(_ result: @escaping FlutterResult) {
         mAudioEngine.inputNode.removeTap(onBus: mRecordBus)
+        stopEngine()
         sendRecorderStatus(SoundStreamStatus.Stopped)
         result(true)
     }


### PR DESCRIPTION
There is an issue that the yellow microphone indicator is still visible, meaning that the resources are nor released correctly after using the microphone.
By adding stopEngine() to stopRecording the problem has gone away in my application.

As I am not an expert in iOS programming, I do not know which consequences this operation has.
Would be great, if this is just the solution, or someone fixes it the right way (in case my solution causes some side-effects).