### PR TITLE
Update SoundStreamPlugin.kt

### DIFF
--- a/android/src/main/kotlin/vn/casperpas/sound_stream/SoundStreamPlugin.kt
+++ b/android/src/main/kotlin/vn/casperpas/sound_stream/SoundStreamPlugin.kt
@@ -179,8 +179,7 @@ public class SoundStreamPlugin : FlutterPlugin,
         }
     }
 
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>?,
-                                            grantResults: IntArray?): Boolean {
+override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray): Boolean {
         when (requestCode) {
             audioRecordPermissionCode -> {
                 if (grantResults != null) {


### PR DESCRIPTION
To fix below exception:

".pub-cache/hosted/pub.dartlang.org/sound_stream-0.3.0/android/src/main/kotlin/vn/casperpas/sound_stream/SoundStreamPlugin.kt: (45, 8): Class 'SoundStreamPlugin' is not abstract and does not implement abstract member public abstract fun onRequestPermissionsResult(p0: Int, p1: Array<(out) String!>, p2: IntArray): Boolean defined in io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener e: /home/devpc/.pub-cache/hosted/pub.dartlang.org/sound_stream-0.3.0/android/src/main/kotlin/vn/casperpas/sound_stream/SoundStreamPlugin.kt: (182, 5): 'onRequestPermissionsResult' overrides nothing FAILURE: Build failed with an exception."