### PR TITLE
Update SwiftSoundStreamPlugin.swift

### DIFF
--- a/ios/Classes/SwiftSoundStreamPlugin.swift
+++ b/ios/Classes/SwiftSoundStreamPlugin.swift
@@ -226,6 +226,7 @@ public class SwiftSoundStreamPlugin: NSObject, FlutterPlugin {
     }
     
     private func stopRecording(_ result: @escaping FlutterResult) {
+        stopEngine()
         mAudioEngine.inputNode.removeTap(onBus: mRecordBus)
         sendRecorderStatus(SoundStreamStatus.Stopped)
         result(true)


### PR DESCRIPTION
stopEngine function was not called previously so it was not stopping the record completely so added stopEngine() to fix the issue. The mic icon will be visible on the iOS devices till the app is destroyed if the stopEngine() is not called.